### PR TITLE
Update Jenkins library to 2.2.0

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 //noinspection GroovyUnusedAssignment
-@Library("Infrastructure@2.4.2") _
+@Library("Infrastructure@2.4.3") _
 
 def product = "plum"
 def branchesToSync = ['ithc', 'perftest', 'demo']

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 //noinspection GroovyUnusedAssignment
-@Library("Infrastructure@2.2.0") _
+@Library("Infrastructure@2.4.2") _
 
 def product = "plum"
 def branchesToSync = ['ithc', 'perftest', 'demo']

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 //noinspection GroovyUnusedAssignment
-@Library("Infrastructure@DTSPO-30107-jenkins-agents") _
+@Library("Infrastructure@2.2.0") _
 
 def product = "plum"
 def branchesToSync = ['ithc', 'perftest', 'demo']

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -1,7 +1,7 @@
 #!groovy
 import groovy.json.JsonSlurper
 
-@Library('Infrastructure@2.4.2') _
+@Library('Infrastructure@2.4.3') _
 
 properties([
     parameters([

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -1,7 +1,7 @@
 #!groovy
 import groovy.json.JsonSlurper
 
-@Library('Infrastructure@DTSPO-30107-jenkins-agents') _
+@Library('Infrastructure@2.2.0') _
 
 properties([
     parameters([

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -1,7 +1,7 @@
 #!groovy
 import groovy.json.JsonSlurper
 
-@Library('Infrastructure@2.2.0') _
+@Library('Infrastructure@2.4.2') _
 
 properties([
     parameters([


### PR DESCRIPTION
Updates Jenkinsfiles to use `Infrastructure@2.2.0` so the pipeline can be validated against the fixed env-agent rollout tag.

No application code changes.
